### PR TITLE
🔗 :: (#21) 시간 내역 확인 및 설정 화면 Publishing

### DIFF
--- a/Projects/App/Sources/Presentation/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/Presentation/MainTab/MainTabFeature.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import FeatureMy
 import FeatureStudent
 import FeatureTeacher
 import Shared
@@ -18,9 +19,11 @@ struct MainTabFeature {
         var selectedTab: Tab = .main
         var studentMain = StudentMainFeature.State()
         var teacherMain = TeacherMainFeature.State()
+        var my: MyFeature.State
 
         init(role: UserRole) {
             self.role = role
+            self.my = MyFeature.State(role: role)
         }
     }
 
@@ -28,6 +31,7 @@ struct MainTabFeature {
         case binding(BindingAction<State>)
         case studentMain(StudentMainFeature.Action)
         case teacherMain(TeacherMainFeature.Action)
+        case my(MyFeature.Action)
     }
 
     init() {}
@@ -38,6 +42,9 @@ struct MainTabFeature {
         }
         Scope(state: \.teacherMain, action: \.teacherMain) {
             TeacherMainFeature()
+        }
+        Scope(state: \.my, action: \.my) {
+            MyFeature()
         }
 
         BindingReducer()
@@ -50,6 +57,9 @@ struct MainTabFeature {
                 return .none
 
             case .teacherMain:
+                return .none
+
+            case .my:
                 return .none
             }
         }

--- a/Projects/App/Sources/Presentation/MainTab/MainTabView.swift
+++ b/Projects/App/Sources/Presentation/MainTab/MainTabView.swift
@@ -34,7 +34,7 @@ struct MainTabView: View {
                     }
                     .tag(Tab.schedule)
 
-                ProfileTabView(role: store.role)
+                ProfileTabView(store: store)
                     .tabItem {
                         Image(store.selectedTab == .profile ? "tabbarPerson" : "tabbarPersonNot")
                     }
@@ -90,10 +90,15 @@ private struct ScheduleTabView: View {
 }
 
 private struct ProfileTabView: View {
-    let role: UserRole
+    let store: StoreOf<MainTabFeature>
 
     var body: some View {
-        MyView(role: role)
+        MyView(
+            store: store.scope(
+                state: \.my,
+                action: \.my
+            )
+        )
     }
 }
 

--- a/Projects/DesignSystem/Sources/View/TotalTimeView.swift
+++ b/Projects/DesignSystem/Sources/View/TotalTimeView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 public struct TotalTimeView: View {
-    var volunteerTime: Int
+    var volunteerTime: Float
 
-    public init(volunteerTime: Int) {
+    public init(volunteerTime: Float) {
         self.volunteerTime = volunteerTime
     }
 
@@ -14,7 +14,7 @@ public struct TotalTimeView: View {
                     .font(.finda(.body3))
                     .foregroundStyle(Color.Gray.gray60)
 
-                Text("\(volunteerTime) 시간")
+                Text("\(String(format: "%.1f", volunteerTime)) 시간")
                     .font(.finda(.heading2))
                     .foregroundStyle(Color.Gray.gray90)
             }

--- a/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
+++ b/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		6D643E00F48A4175C5FF556A /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A0FF3339A9472B5423DB2EF /* Shared.framework */; };
 		88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */; };
 		88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E42F497A81003AD410 /* HistoryListCell.swift */; };
+		88B726E82F49803B003AD410 /* MyFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E72F498036003AD410 /* MyFeature.swift */; };
 		88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */; };
 		88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB9812F47205200BCF183 /* VolunteerFilter.swift */; };
 		8F8AB04B00A002ABB6D7DA68 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */; };
@@ -40,6 +41,7 @@
 		7A660683DAA87CD4A880216E /* STAGE.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = STAGE.xcconfig; sourceTree = "<group>"; };
 		88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryView.swift; sourceTree = "<group>"; };
 		88B726E42F497A81003AD410 /* HistoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListCell.swift; sourceTree = "<group>"; };
+		88B726E72F498036003AD410 /* MyFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeature.swift; sourceTree = "<group>"; };
 		88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilterListView.swift; sourceTree = "<group>"; };
 		88BCB9812F47205200BCF183 /* VolunteerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilter.swift; sourceTree = "<group>"; };
 		AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -123,6 +125,7 @@
 				88BCB97D2F47198E00BCF183 /* Component */,
 				88B726E12F485212003AD410 /* VolunteerHistory */,
 				43C7DE561CBB0DA717BC420B /* MyView.swift */,
+				88B726E72F498036003AD410 /* MyFeature.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 				88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */,
 				FAFB6C9FE3261102F8B8FCCA /* VolunteerRoleScrollView.swift in Sources */,
 				88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */,
+				88B726E82F49803B003AD410 /* MyFeature.swift in Sources */,
 				88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */,
 				88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */,
 				B3D1350B05F9E742EE22FAB3 /* MyView.swift in Sources */,

--- a/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
+++ b/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		26C1D83730A005800CEB2B9A /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC598270D2E18BAA56861838 /* ComposableArchitecture.framework */; };
 		6D643E00F48A4175C5FF556A /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A0FF3339A9472B5423DB2EF /* Shared.framework */; };
 		88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */; };
+		88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E42F497A81003AD410 /* HistoryListCell.swift */; };
 		88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */; };
 		88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB9812F47205200BCF183 /* VolunteerFilter.swift */; };
 		8F8AB04B00A002ABB6D7DA68 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */; };
@@ -38,6 +39,7 @@
 		75358356FF54D62500BB6248 /* VolunteerRoleScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerRoleScrollView.swift; sourceTree = "<group>"; };
 		7A660683DAA87CD4A880216E /* STAGE.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = STAGE.xcconfig; sourceTree = "<group>"; };
 		88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryView.swift; sourceTree = "<group>"; };
+		88B726E42F497A81003AD410 /* HistoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListCell.swift; sourceTree = "<group>"; };
 		88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilterListView.swift; sourceTree = "<group>"; };
 		88BCB9812F47205200BCF183 /* VolunteerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilter.swift; sourceTree = "<group>"; };
 		AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,9 +85,18 @@
 		88B726E12F485212003AD410 /* VolunteerHistory */ = {
 			isa = PBXGroup;
 			children = (
+				88B726E62F497A84003AD410 /* Component */,
 				88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */,
 			);
 			path = VolunteerHistory;
+			sourceTree = "<group>";
+		};
+		88B726E62F497A84003AD410 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				88B726E42F497A81003AD410 /* HistoryListCell.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		88BCB97D2F47198E00BCF183 /* Component */ = {
@@ -250,6 +261,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */,
 				FAFB6C9FE3261102F8B8FCCA /* VolunteerRoleScrollView.swift in Sources */,
 				88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */,
 				88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */,

--- a/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
+++ b/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		26C1D83730A005800CEB2B9A /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC598270D2E18BAA56861838 /* ComposableArchitecture.framework */; };
 		6D643E00F48A4175C5FF556A /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A0FF3339A9472B5423DB2EF /* Shared.framework */; };
+		88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */; };
 		88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */; };
 		88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB9812F47205200BCF183 /* VolunteerFilter.swift */; };
 		8F8AB04B00A002ABB6D7DA68 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */; };
@@ -36,6 +37,7 @@
 		706BE6009C5B57A3EE65AE7B /* FeatureMy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FeatureMy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		75358356FF54D62500BB6248 /* VolunteerRoleScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerRoleScrollView.swift; sourceTree = "<group>"; };
 		7A660683DAA87CD4A880216E /* STAGE.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = STAGE.xcconfig; sourceTree = "<group>"; };
+		88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryView.swift; sourceTree = "<group>"; };
 		88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilterListView.swift; sourceTree = "<group>"; };
 		88BCB9812F47205200BCF183 /* VolunteerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilter.swift; sourceTree = "<group>"; };
 		AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -78,6 +80,14 @@
 			);
 			sourceTree = "<group>";
 		};
+		88B726E12F485212003AD410 /* VolunteerHistory */ = {
+			isa = PBXGroup;
+			children = (
+				88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */,
+			);
+			path = VolunteerHistory;
+			sourceTree = "<group>";
+		};
 		88BCB97D2F47198E00BCF183 /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -100,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				88BCB97D2F47198E00BCF183 /* Component */,
+				88B726E12F485212003AD410 /* VolunteerHistory */,
 				43C7DE561CBB0DA717BC420B /* MyView.swift */,
 			);
 			path = Sources;
@@ -242,6 +253,7 @@
 				FAFB6C9FE3261102F8B8FCCA /* VolunteerRoleScrollView.swift in Sources */,
 				88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */,
 				88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */,
+				88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */,
 				B3D1350B05F9E742EE22FAB3 /* MyView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
+++ b/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		88B726E82F49803B003AD410 /* MyFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E72F498036003AD410 /* MyFeature.swift */; };
 		88B726EA2F4981AB003AD410 /* VolunteerHistoryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */; };
 		88B726ED2F498511003AD410 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726EC2F49850D003AD410 /* SettingView.swift */; };
+		88B726F02F498733003AD410 /* SettingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726EF2F498726003AD410 /* SettingButton.swift */; };
 		88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */; };
 		88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB9812F47205200BCF183 /* VolunteerFilter.swift */; };
 		8F8AB04B00A002ABB6D7DA68 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */; };
@@ -46,6 +47,7 @@
 		88B726E72F498036003AD410 /* MyFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeature.swift; sourceTree = "<group>"; };
 		88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryFeature.swift; sourceTree = "<group>"; };
 		88B726EC2F49850D003AD410 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
+		88B726EF2F498726003AD410 /* SettingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingButton.swift; sourceTree = "<group>"; };
 		88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilterListView.swift; sourceTree = "<group>"; };
 		88BCB9812F47205200BCF183 /* VolunteerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilter.swift; sourceTree = "<group>"; };
 		AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -109,9 +111,18 @@
 		88B726EB2F498502003AD410 /* Setting */ = {
 			isa = PBXGroup;
 			children = (
+				88B726EE2F49871A003AD410 /* Component */,
 				88B726EC2F49850D003AD410 /* SettingView.swift */,
 			);
 			path = Setting;
+			sourceTree = "<group>";
+		};
+		88B726EE2F49871A003AD410 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				88B726EF2F498726003AD410 /* SettingButton.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		88BCB97D2F47198E00BCF183 /* Component */ = {
@@ -286,6 +297,7 @@
 				88B726E82F49803B003AD410 /* MyFeature.swift in Sources */,
 				88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */,
 				88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */,
+				88B726F02F498733003AD410 /* SettingButton.swift in Sources */,
 				B3D1350B05F9E742EE22FAB3 /* MyView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
+++ b/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
@@ -8,19 +8,21 @@
 
 /* Begin PBXBuildFile section */
 		26C1D83730A005800CEB2B9A /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC598270D2E18BAA56861838 /* ComposableArchitecture.framework */; };
+		2C008117BED5FD10CFE140C8 /* VolunteerHistoryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64DD0DCDA468F8564524CA52 /* VolunteerHistoryFeature.swift */; };
+		4D95A1173050AACD5CFF0E45 /* VolunteerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A8BE516E81C1FC40C91A542 /* VolunteerFilter.swift */; };
+		62834F5E9A0CF2B58FED76C8 /* MyFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE18947BF7590754554D5A8F /* MyFeature.swift */; };
 		6D643E00F48A4175C5FF556A /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A0FF3339A9472B5423DB2EF /* Shared.framework */; };
-		88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */; };
-		88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E42F497A81003AD410 /* HistoryListCell.swift */; };
-		88B726E82F49803B003AD410 /* MyFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E72F498036003AD410 /* MyFeature.swift */; };
-		88B726EA2F4981AB003AD410 /* VolunteerHistoryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */; };
-		88B726ED2F498511003AD410 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726EC2F49850D003AD410 /* SettingView.swift */; };
-		88B726F02F498733003AD410 /* SettingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726EF2F498726003AD410 /* SettingButton.swift */; };
-		88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */; };
-		88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB9812F47205200BCF183 /* VolunteerFilter.swift */; };
+		88417DAF2F4ACB5200AC9056 /* SettingPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88417DAE2F4ACB4600AC9056 /* SettingPopup.swift */; };
+		88417DB12F4AD51100AC9056 /* SettingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88417DB02F4AD50D00AC9056 /* SettingFeature.swift */; };
 		8F8AB04B00A002ABB6D7DA68 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */; };
+		9D384827AAF726D309F3640B /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983EBE0CA76BA580E6853FA4 /* SettingView.swift */; };
+		A4967FE32E8FBFE79CF81AFE /* VolunteerHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82ED391582F32D1A605F83F7 /* VolunteerHistoryView.swift */; };
+		A7C2EA9A6C580C815C812D61 /* HistoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E085B90B16E46E7E44FA82 /* HistoryListCell.swift */; };
 		B3D1350B05F9E742EE22FAB3 /* MyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C7DE561CBB0DA717BC420B /* MyView.swift */; };
+		C550DD69C526AE7815C1553D /* SettingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C6E516219E668C7B1F6465 /* SettingButton.swift */; };
+		E1CB6179E355E74AC9BA44B0 /* VolunteerFilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BFEFE2F4F58881E69059B5 /* VolunteerFilterListView.swift */; };
+		EA9875BE67A5AB9A1D794CFC /* VolunteerRoleScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EAFBC6D3ACABFE3625B0053 /* VolunteerRoleScrollView.swift */; };
 		F00628E7F7BC786C30B6DCF1 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A8054F5CCC9AB7C0E7DA39 /* Core.framework */; };
-		FAFB6C9FE3261102F8B8FCCA /* VolunteerRoleScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75358356FF54D62500BB6248 /* VolunteerRoleScrollView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -37,22 +39,24 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2A8BE516E81C1FC40C91A542 /* VolunteerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilter.swift; sourceTree = "<group>"; };
 		43C7DE561CBB0DA717BC420B /* MyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyView.swift; sourceTree = "<group>"; };
 		4A0FF3339A9472B5423DB2EF /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		54C6E516219E668C7B1F6465 /* SettingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingButton.swift; sourceTree = "<group>"; };
+		64DD0DCDA468F8564524CA52 /* VolunteerHistoryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryFeature.swift; sourceTree = "<group>"; };
 		706BE6009C5B57A3EE65AE7B /* FeatureMy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FeatureMy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		75358356FF54D62500BB6248 /* VolunteerRoleScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerRoleScrollView.swift; sourceTree = "<group>"; };
 		7A660683DAA87CD4A880216E /* STAGE.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = STAGE.xcconfig; sourceTree = "<group>"; };
-		88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryView.swift; sourceTree = "<group>"; };
-		88B726E42F497A81003AD410 /* HistoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListCell.swift; sourceTree = "<group>"; };
-		88B726E72F498036003AD410 /* MyFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeature.swift; sourceTree = "<group>"; };
-		88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryFeature.swift; sourceTree = "<group>"; };
-		88B726EC2F49850D003AD410 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
-		88B726EF2F498726003AD410 /* SettingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingButton.swift; sourceTree = "<group>"; };
-		88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilterListView.swift; sourceTree = "<group>"; };
-		88BCB9812F47205200BCF183 /* VolunteerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilter.swift; sourceTree = "<group>"; };
+		82ED391582F32D1A605F83F7 /* VolunteerHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryView.swift; sourceTree = "<group>"; };
+		88417DAE2F4ACB4600AC9056 /* SettingPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingPopup.swift; sourceTree = "<group>"; };
+		88417DB02F4AD50D00AC9056 /* SettingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingFeature.swift; sourceTree = "<group>"; };
+		8EAFBC6D3ACABFE3625B0053 /* VolunteerRoleScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerRoleScrollView.swift; sourceTree = "<group>"; };
+		983EBE0CA76BA580E6853FA4 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
+		A5E085B90B16E46E7E44FA82 /* HistoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListCell.swift; sourceTree = "<group>"; };
 		AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2A434088CC8F5EEF11042B7 /* FeatureMy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "FeatureMy-Info.plist"; sourceTree = "<group>"; };
+		C0BFEFE2F4F58881E69059B5 /* VolunteerFilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilterListView.swift; sourceTree = "<group>"; };
 		C1A8054F5CCC9AB7C0E7DA39 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE18947BF7590754554D5A8F /* MyFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeature.swift; sourceTree = "<group>"; };
 		EC598270D2E18BAA56861838 /* ComposableArchitecture.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ComposableArchitecture.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC9FA9C1DCD6083CCAE72342 /* PROD.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PROD.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -72,6 +76,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1B8ED3171FA3EC39AE392548 /* VolunteerHistory */ = {
+			isa = PBXGroup;
+			children = (
+				E4D83ACA325604BDA3691E2C /* Component */,
+				64DD0DCDA468F8564524CA52 /* VolunteerHistoryFeature.swift */,
+				82ED391582F32D1A605F83F7 /* VolunteerHistoryView.swift */,
+			);
+			path = VolunteerHistory;
+			sourceTree = "<group>";
+		};
+		3167B357DE51B6941998D218 /* VolunteerFilter */ = {
+			isa = PBXGroup;
+			children = (
+				2A8BE516E81C1FC40C91A542 /* VolunteerFilter.swift */,
+				C0BFEFE2F4F58881E69059B5 /* VolunteerFilterListView.swift */,
+			);
+			path = VolunteerFilter;
+			sourceTree = "<group>";
+		};
 		6D5BB5FFC91BFE47D67D5E79 /* Project */ = {
 			isa = PBXGroup;
 			children = (
@@ -82,6 +105,15 @@
 			name = Project;
 			sourceTree = "<group>";
 		};
+		76277018BBAD5618E302907C /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				3167B357DE51B6941998D218 /* VolunteerFilter */,
+				8EAFBC6D3ACABFE3625B0053 /* VolunteerRoleScrollView.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
 		76EF18C32B36AFDF5B4C9FDE = {
 			isa = PBXGroup;
 			children = (
@@ -90,69 +122,26 @@
 			);
 			sourceTree = "<group>";
 		};
-		88B726E12F485212003AD410 /* VolunteerHistory */ = {
-			isa = PBXGroup;
-			children = (
-				88B726E62F497A84003AD410 /* Component */,
-				88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */,
-				88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */,
-			);
-			path = VolunteerHistory;
-			sourceTree = "<group>";
-		};
-		88B726E62F497A84003AD410 /* Component */ = {
-			isa = PBXGroup;
-			children = (
-				88B726E42F497A81003AD410 /* HistoryListCell.swift */,
-			);
-			path = Component;
-			sourceTree = "<group>";
-		};
-		88B726EB2F498502003AD410 /* Setting */ = {
-			isa = PBXGroup;
-			children = (
-				88B726EE2F49871A003AD410 /* Component */,
-				88B726EC2F49850D003AD410 /* SettingView.swift */,
-			);
-			path = Setting;
-			sourceTree = "<group>";
-		};
-		88B726EE2F49871A003AD410 /* Component */ = {
-			isa = PBXGroup;
-			children = (
-				88B726EF2F498726003AD410 /* SettingButton.swift */,
-			);
-			path = Component;
-			sourceTree = "<group>";
-		};
-		88BCB97D2F47198E00BCF183 /* Component */ = {
-			isa = PBXGroup;
-			children = (
-				88BCB9832F47214700BCF183 /* VolunteerFilter */,
-				75358356FF54D62500BB6248 /* VolunteerRoleScrollView.swift */,
-			);
-			path = Component;
-			sourceTree = "<group>";
-		};
-		88BCB9832F47214700BCF183 /* VolunteerFilter */ = {
-			isa = PBXGroup;
-			children = (
-				88BCB9812F47205200BCF183 /* VolunteerFilter.swift */,
-				88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */,
-			);
-			path = VolunteerFilter;
-			sourceTree = "<group>";
-		};
 		8FC8E1CCD202365C8DF98FC3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				88BCB97D2F47198E00BCF183 /* Component */,
-				88B726EB2F498502003AD410 /* Setting */,
-				88B726E12F485212003AD410 /* VolunteerHistory */,
+				76277018BBAD5618E302907C /* Component */,
+				A0C5E55892043C7C5F900CB5 /* Setting */,
+				1B8ED3171FA3EC39AE392548 /* VolunteerHistory */,
+				DE18947BF7590754554D5A8F /* MyFeature.swift */,
 				43C7DE561CBB0DA717BC420B /* MyView.swift */,
-				88B726E72F498036003AD410 /* MyFeature.swift */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		A0C5E55892043C7C5F900CB5 /* Setting */ = {
+			isa = PBXGroup;
+			children = (
+				D1FA8481FCA4310B2092DB7C /* Component */,
+				983EBE0CA76BA580E6853FA4 /* SettingView.swift */,
+				88417DB02F4AD50D00AC9056 /* SettingFeature.swift */,
+			);
+			path = Setting;
 			sourceTree = "<group>";
 		};
 		C893D5CDE1454AD6941477E3 /* FeatureMy */ = {
@@ -162,6 +151,15 @@
 				7A660683DAA87CD4A880216E /* STAGE.xcconfig */,
 			);
 			path = FeatureMy;
+			sourceTree = "<group>";
+		};
+		D1FA8481FCA4310B2092DB7C /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				88417DAE2F4ACB4600AC9056 /* SettingPopup.swift */,
+				54C6E516219E668C7B1F6465 /* SettingButton.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		D9E780483472CC877C2F08C7 /* Products */ = {
@@ -182,6 +180,14 @@
 				B2A434088CC8F5EEF11042B7 /* FeatureMy-Info.plist */,
 			);
 			path = InfoPlists;
+			sourceTree = "<group>";
+		};
+		E4D83ACA325604BDA3691E2C /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				A5E085B90B16E46E7E44FA82 /* HistoryListCell.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		E6BDCB3F119F05DD243A6B5D /* Derived */ = {
@@ -289,16 +295,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */,
-				FAFB6C9FE3261102F8B8FCCA /* VolunteerRoleScrollView.swift in Sources */,
-				88B726EA2F4981AB003AD410 /* VolunteerHistoryFeature.swift in Sources */,
-				88B726ED2F498511003AD410 /* SettingView.swift in Sources */,
-				88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */,
-				88B726E82F49803B003AD410 /* MyFeature.swift in Sources */,
-				88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */,
-				88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */,
-				88B726F02F498733003AD410 /* SettingButton.swift in Sources */,
+				4D95A1173050AACD5CFF0E45 /* VolunteerFilter.swift in Sources */,
+				E1CB6179E355E74AC9BA44B0 /* VolunteerFilterListView.swift in Sources */,
+				88417DAF2F4ACB5200AC9056 /* SettingPopup.swift in Sources */,
+				EA9875BE67A5AB9A1D794CFC /* VolunteerRoleScrollView.swift in Sources */,
+				62834F5E9A0CF2B58FED76C8 /* MyFeature.swift in Sources */,
 				B3D1350B05F9E742EE22FAB3 /* MyView.swift in Sources */,
+				C550DD69C526AE7815C1553D /* SettingButton.swift in Sources */,
+				9D384827AAF726D309F3640B /* SettingView.swift in Sources */,
+				A7C2EA9A6C580C815C812D61 /* HistoryListCell.swift in Sources */,
+				88417DB12F4AD51100AC9056 /* SettingFeature.swift in Sources */,
+				2C008117BED5FD10CFE140C8 /* VolunteerHistoryFeature.swift in Sources */,
+				A4967FE32E8FBFE79CF81AFE /* VolunteerHistoryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
+++ b/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		88B726E32F485247003AD410 /* VolunteerHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */; };
 		88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E42F497A81003AD410 /* HistoryListCell.swift */; };
 		88B726E82F49803B003AD410 /* MyFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E72F498036003AD410 /* MyFeature.swift */; };
+		88B726EA2F4981AB003AD410 /* VolunteerHistoryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */; };
 		88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */; };
 		88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB9812F47205200BCF183 /* VolunteerFilter.swift */; };
 		8F8AB04B00A002ABB6D7DA68 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */; };
@@ -42,6 +43,7 @@
 		88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryView.swift; sourceTree = "<group>"; };
 		88B726E42F497A81003AD410 /* HistoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListCell.swift; sourceTree = "<group>"; };
 		88B726E72F498036003AD410 /* MyFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeature.swift; sourceTree = "<group>"; };
+		88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryFeature.swift; sourceTree = "<group>"; };
 		88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilterListView.swift; sourceTree = "<group>"; };
 		88BCB9812F47205200BCF183 /* VolunteerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilter.swift; sourceTree = "<group>"; };
 		AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -89,6 +91,7 @@
 			children = (
 				88B726E62F497A84003AD410 /* Component */,
 				88B726E22F48523D003AD410 /* VolunteerHistoryView.swift */,
+				88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */,
 			);
 			path = VolunteerHistory;
 			sourceTree = "<group>";
@@ -266,6 +269,7 @@
 			files = (
 				88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */,
 				FAFB6C9FE3261102F8B8FCCA /* VolunteerRoleScrollView.swift in Sources */,
+				88B726EA2F4981AB003AD410 /* VolunteerHistoryFeature.swift in Sources */,
 				88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */,
 				88B726E82F49803B003AD410 /* MyFeature.swift in Sources */,
 				88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */,

--- a/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
+++ b/Projects/Features/FeatureMy/FeatureMy.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E42F497A81003AD410 /* HistoryListCell.swift */; };
 		88B726E82F49803B003AD410 /* MyFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E72F498036003AD410 /* MyFeature.swift */; };
 		88B726EA2F4981AB003AD410 /* VolunteerHistoryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */; };
+		88B726ED2F498511003AD410 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726EC2F49850D003AD410 /* SettingView.swift */; };
 		88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */; };
 		88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BCB9812F47205200BCF183 /* VolunteerFilter.swift */; };
 		8F8AB04B00A002ABB6D7DA68 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */; };
@@ -44,6 +45,7 @@
 		88B726E42F497A81003AD410 /* HistoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListCell.swift; sourceTree = "<group>"; };
 		88B726E72F498036003AD410 /* MyFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeature.swift; sourceTree = "<group>"; };
 		88B726E92F49819D003AD410 /* VolunteerHistoryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerHistoryFeature.swift; sourceTree = "<group>"; };
+		88B726EC2F49850D003AD410 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		88BCB97E2F471B2900BCF183 /* VolunteerFilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilterListView.swift; sourceTree = "<group>"; };
 		88BCB9812F47205200BCF183 /* VolunteerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolunteerFilter.swift; sourceTree = "<group>"; };
 		AA4BCA2EB5199D14C002D08A /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -104,6 +106,14 @@
 			path = Component;
 			sourceTree = "<group>";
 		};
+		88B726EB2F498502003AD410 /* Setting */ = {
+			isa = PBXGroup;
+			children = (
+				88B726EC2F49850D003AD410 /* SettingView.swift */,
+			);
+			path = Setting;
+			sourceTree = "<group>";
+		};
 		88BCB97D2F47198E00BCF183 /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -126,6 +136,7 @@
 			isa = PBXGroup;
 			children = (
 				88BCB97D2F47198E00BCF183 /* Component */,
+				88B726EB2F498502003AD410 /* Setting */,
 				88B726E12F485212003AD410 /* VolunteerHistory */,
 				43C7DE561CBB0DA717BC420B /* MyView.swift */,
 				88B726E72F498036003AD410 /* MyFeature.swift */,
@@ -270,6 +281,7 @@
 				88B726E52F497A82003AD410 /* HistoryListCell.swift in Sources */,
 				FAFB6C9FE3261102F8B8FCCA /* VolunteerRoleScrollView.swift in Sources */,
 				88B726EA2F4981AB003AD410 /* VolunteerHistoryFeature.swift in Sources */,
+				88B726ED2F498511003AD410 /* SettingView.swift in Sources */,
 				88BCB97F2F471B3000BCF183 /* VolunteerFilterListView.swift in Sources */,
 				88B726E82F49803B003AD410 /* MyFeature.swift in Sources */,
 				88BCB9822F47206900BCF183 /* VolunteerFilter.swift in Sources */,

--- a/Projects/Features/FeatureMy/Sources/MyFeature.swift
+++ b/Projects/Features/FeatureMy/Sources/MyFeature.swift
@@ -1,0 +1,30 @@
+import ComposableArchitecture
+import Shared
+
+@Reducer
+public struct MyFeature {
+    @ObservableState
+    public struct State: Equatable {
+        var role: UserRole
+
+        public init(role: UserRole) {
+            self.role = role
+        }
+    }
+
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
+    }
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/FeatureMy/Sources/MyFeature.swift
+++ b/Projects/Features/FeatureMy/Sources/MyFeature.swift
@@ -6,6 +6,7 @@ public struct MyFeature {
     @ObservableState
     public struct State: Equatable {
         var role: UserRole
+        var path = StackState<Path.State>()
 
         public init(role: UserRole) {
             self.role = role
@@ -14,6 +15,13 @@ public struct MyFeature {
 
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
+        case volunteerHistoryButtonTapped
+        case path(StackActionOf<Path>)
+    }
+
+    @Reducer
+    public enum Path {
+        case volunteerHistory(VolunteerHistoryFeature)
     }
 
     public init() {}
@@ -22,9 +30,20 @@ public struct MyFeature {
         BindingReducer()
         Reduce { state, action in
             switch action {
+            case .volunteerHistoryButtonTapped:
+                guard state.role == .student else { return .none }
+                state.path.append(.volunteerHistory(VolunteerHistoryFeature.State()))
+                return .none
+
             case .binding:
+                return .none
+
+            case .path:
                 return .none
             }
         }
+        .forEach(\.path, action: \.path)
     }
 }
+
+extension MyFeature.Path.State: Equatable {}

--- a/Projects/Features/FeatureMy/Sources/MyFeature.swift
+++ b/Projects/Features/FeatureMy/Sources/MyFeature.swift
@@ -15,12 +15,14 @@ public struct MyFeature {
 
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
+        case settingButtonTapped
         case volunteerHistoryButtonTapped
         case path(StackActionOf<Path>)
     }
 
     @Reducer
     public enum Path {
+        case setting(SettingFeature)
         case volunteerHistory(VolunteerHistoryFeature)
     }
 
@@ -30,6 +32,9 @@ public struct MyFeature {
         BindingReducer()
         Reduce { state, action in
             switch action {
+            case .settingButtonTapped:
+                state.path.append(.setting(SettingFeature.State()))
+                return .none
             case .volunteerHistoryButtonTapped:
                 guard state.role == .student else { return .none }
                 state.path.append(.volunteerHistory(VolunteerHistoryFeature.State()))

--- a/Projects/Features/FeatureMy/Sources/MyView.swift
+++ b/Projects/Features/FeatureMy/Sources/MyView.swift
@@ -43,7 +43,7 @@ public struct MyView: View {
                         }
                         Spacer()
 
-                        Button(action: {}, label: {
+                        Button(action: { store.send(.settingButtonTapped) }, label: {
                             Image.Icons.setting
                         })
                     }
@@ -72,6 +72,14 @@ public struct MyView: View {
                 .padding(.top, 24)
             } destination: { pathStore in
                 switch pathStore.state {
+                case .setting:
+                    IfLetStore(pathStore.scope(
+                        state: \.setting,
+                        action: \.setting
+                    ),
+                    then: SettingView.init
+                    )
+
                 case .volunteerHistory:
                     IfLetStore(
                         pathStore.scope(

--- a/Projects/Features/FeatureMy/Sources/MyView.swift
+++ b/Projects/Features/FeatureMy/Sources/MyView.swift
@@ -9,7 +9,7 @@ public struct MyView: View {
     private let roles = ["환경지킴이", "교감쌤과 바둑두기", "화단에 물주기"]
     @State private var selectedFilter: VolunteerStatus = .all
 
-    init(store: StoreOf<MyFeature>) {
+    public init(store: StoreOf<MyFeature>) {
         self.store = store
     }
 
@@ -22,51 +22,66 @@ public struct MyView: View {
 
     public var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 16) {
-                HStack(spacing: 16) {
-                    Image.Images.baseProfile
-                        .resizable()
-                        .frame(width: 48, height: 48)
-                        .clipShape(Circle())
-                    
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(studentName)
-                            .font(.finda(.body1))
-                            .foregroundColor(.Gray.gray90)
-                        
-                        if store.role == .student {
-                            VolunteerRoleScrollView(roles: roles)
+            NavigationStackStore(
+                store.scope(state: \.path, action: \.path)
+            ) {
+                VStack(spacing: 16) {
+                    HStack(spacing: 16) {
+                        Image.Images.baseProfile
+                            .resizable()
+                            .frame(width: 48, height: 48)
+                            .clipShape(Circle())
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(studentName)
+                                .font(.finda(.body1))
+                                .foregroundColor(.Gray.gray90)
+
+                            if store.role == .student {
+                                VolunteerRoleScrollView(roles: roles)
+                            }
                         }
+                        Spacer()
+
+                        Button(action: {}, label: {
+                            Image.Icons.setting
+                        })
                     }
-                    Spacer()
-                    
-                    Button(action: {}, label: {
-                        Image.Icons.setting
+
+                    Button(action: { store.send(.volunteerHistoryButtonTapped) }, label: {
+                        Text(store.role == .student ? "봉사 활동 내역 확인" : "공지사항 관리/생성")
+                            .font(.finda(.body1))
+                            .foregroundColor(.Blue.blue50)
+
+                        Spacer()
+
+                        Image.Icons.rightArrow
+                            .renderingMode(.template)
+                            .foregroundColor(.Blue.blue50)
                     })
-                }
-                
-                Button(action: {}, label: {
-                    Text(store.role == .student ? "봉사 활동 내역 확인" : "공지사항 관리/생성")
-                        .font(.finda(.body1))
-                        .foregroundColor(.Blue.blue50)
-                    
+                    .padding(18)
+                    .background(Color.Blue.blue10)
+                    .cornerRadius(16)
+
+                    VolunteerFilterView(selectedFilter: $selectedFilter)
+                    VolunteerListView(activities: filteredActivities)
+
                     Spacer()
-                    
-                    Image.Icons.rightArrow
-                        .renderingMode(.template)
-                        .foregroundColor(.Blue.blue50)
-                })
-                .padding(18)
-                .background(Color.Blue.blue10)
-                .cornerRadius(16)
-                
-                VolunteerFilterView(selectedFilter: $selectedFilter)
-                VolunteerListView(activities: filteredActivities)
-                
-                Spacer()
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+            } destination: { pathStore in
+                switch pathStore.state {
+                case .volunteerHistory:
+                    IfLetStore(
+                        pathStore.scope(
+                            state: \.volunteerHistory,
+                            action: \.volunteerHistory
+                        ),
+                        then: VolunteerHistoryView.init
+                    )
+                }
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 24)
         }
     }
 }

--- a/Projects/Features/FeatureMy/Sources/MyView.swift
+++ b/Projects/Features/FeatureMy/Sources/MyView.swift
@@ -1,15 +1,16 @@
 import SwiftUI
+import ComposableArchitecture
 import DesignSystem
-import Shared
 
 public struct MyView: View {
-    private let role: UserRole
+    @Perception.Bindable private var store: StoreOf<MyFeature>
+
     private let studentName = "2216 하원"
     private let roles = ["환경지킴이", "교감쌤과 바둑두기", "화단에 물주기"]
     @State private var selectedFilter: VolunteerStatus = .all
 
-    public init(role: UserRole) {
-        self.role = role
+    init(store: StoreOf<MyFeature>) {
+        self.store = store
     }
 
     private var filteredActivities: [VolunteerListResponse] {
@@ -20,54 +21,60 @@ public struct MyView: View {
     }
 
     public var body: some View {
-        VStack(spacing: 16) {
-            HStack(spacing: 16) {
-                Image.Images.baseProfile
-                    .resizable()
-                    .frame(width: 48, height: 48)
-                    .clipShape(Circle())
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(studentName)
-                        .font(.finda(.body1))
-                        .foregroundColor(.Gray.gray90)
-
-                    if role == .student {
-                        VolunteerRoleScrollView(roles: roles)
+        WithPerceptionTracking {
+            VStack(spacing: 16) {
+                HStack(spacing: 16) {
+                    Image.Images.baseProfile
+                        .resizable()
+                        .frame(width: 48, height: 48)
+                        .clipShape(Circle())
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(studentName)
+                            .font(.finda(.body1))
+                            .foregroundColor(.Gray.gray90)
+                        
+                        if store.role == .student {
+                            VolunteerRoleScrollView(roles: roles)
+                        }
                     }
+                    Spacer()
+                    
+                    Button(action: {}, label: {
+                        Image.Icons.setting
+                    })
                 }
-                Spacer()
-
+                
                 Button(action: {}, label: {
-                    Image.Icons.setting
+                    Text(store.role == .student ? "봉사 활동 내역 확인" : "공지사항 관리/생성")
+                        .font(.finda(.body1))
+                        .foregroundColor(.Blue.blue50)
+                    
+                    Spacer()
+                    
+                    Image.Icons.rightArrow
+                        .renderingMode(.template)
+                        .foregroundColor(.Blue.blue50)
                 })
-            }
-
-            Button(action: {}, label: {
-                Text(role == .student ? "봉사 활동 내역 확인" : "공지사항 관리/생성")
-                    .font(.finda(.body1))
-                    .foregroundColor(.Blue.blue50)
-
+                .padding(18)
+                .background(Color.Blue.blue10)
+                .cornerRadius(16)
+                
+                VolunteerFilterView(selectedFilter: $selectedFilter)
+                VolunteerListView(activities: filteredActivities)
+                
                 Spacer()
-
-                Image.Icons.rightArrow
-                    .renderingMode(.template)
-                    .foregroundColor(.Blue.blue50)
-            })
-            .padding(18)
-            .background(Color.Blue.blue10)
-            .cornerRadius(16)
-
-            VolunteerFilterView(selectedFilter: $selectedFilter)
-            VolunteerListView(activities: filteredActivities)
-
-            Spacer()
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
         }
-        .padding(.horizontal, 24)
-        .padding(.top, 24)
     }
 }
 
 #Preview {
-    MyView(role: .student)
+    MyView(
+        store: Store(initialState: MyFeature.State(role: .student)) {
+            MyFeature()
+        }
+    )
 }

--- a/Projects/Features/FeatureMy/Sources/Setting/Component/SettingButton.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/Component/SettingButton.swift
@@ -6,7 +6,7 @@ struct SettingButton: View {
     var textColor: Color?
     var action: () -> Void
 
-    public init(
+    init(
         buttonText: String,
         textColor: Color? = Color.Sub.red20,
         action: @escaping () -> Void

--- a/Projects/Features/FeatureMy/Sources/Setting/Component/SettingButton.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/Component/SettingButton.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import DesignSystem
+
+struct SettingButton: View {
+    var buttonText: String
+    var textColor: Color?
+    var action: () -> Void
+
+    public init(
+        buttonText: String,
+        textColor: Color? = Color.Sub.red20,
+        action: @escaping () -> Void
+    ) {
+        self.buttonText = buttonText
+        self.textColor = textColor
+        self.action = action
+    }
+
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            HStack {
+                Text(buttonText)
+                    .font(.finda(.body1))
+                    .foregroundStyle(textColor!)
+
+                Spacer()
+
+                Image.Icons.rightArrow
+            }
+            .padding(18)
+            .background(Color.Gray.gray20)
+            .clipShape(.rect(cornerRadius: 16))
+        }
+    }
+}
+
+#Preview {
+    SettingButton(
+        buttonText: "로그아웃",
+        action: {}
+    )
+}

--- a/Projects/Features/FeatureMy/Sources/Setting/Component/SettingPopup.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/Component/SettingPopup.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 import DesignSystem
 
-public struct SettingPopup: View {
+struct SettingPopup: View {
     var title: String
     var content: String
     var cancelAction: () -> Void
     var okAction: () -> Void
 
-    public init(
+    init(
         title: String,
         content: String,
         cancelAction: @escaping () -> Void = {},
@@ -19,7 +19,7 @@ public struct SettingPopup: View {
         self.okAction = okAction
     }
 
-    public var body: some View {
+    var body: some View {
         VStack(spacing: 12) {
             Text(title)
                 .font(.finda(.subheading2))

--- a/Projects/Features/FeatureMy/Sources/Setting/Component/SettingPopup.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/Component/SettingPopup.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import DesignSystem
+
+public struct SettingPopup: View {
+    var title: String
+    var content: String
+    var cancelAction: () -> Void
+    var okAction: () -> Void
+
+    public init(
+        title: String,
+        content: String,
+        cancelAction: @escaping () -> Void = {},
+        okAction: @escaping () -> Void = {}
+    ) {
+        self.title = title
+        self.content = content
+        self.cancelAction = cancelAction
+        self.okAction = okAction
+    }
+
+    public var body: some View {
+        VStack(spacing: 12) {
+            Text(title)
+                .font(.finda(.subheading2))
+                .foregroundStyle(Color.Sub.red20)
+
+            Text(content)
+                .font(.finda(.body4))
+                .foregroundStyle(Color.Gray.gray60)
+                .multilineTextAlignment(.center)
+
+            HStack(spacing: 16) {
+                Button(action: { cancelAction() }, label: {
+                    Text("취소")
+                        .font(.finda(.body3))
+                        .foregroundStyle(Color.Gray.gray60)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                })
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Color.Gray.gray30)
+                )
+
+                Button(action: { okAction() }, label: {
+                    Text(title)
+                        .font(.finda(.body3))
+                        .foregroundStyle(Color.Sub.red20)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                })
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Color.Sub.red10)
+                )
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.Gray.gray10)
+        )
+    }
+}
+
+#Preview {
+    VStack {
+        SettingPopup(
+            title: "로그아웃",
+            content: "정말 로그아웃 하시겠습니까?\n로그아웃 시 다시 로그인해야 합니다.",
+            cancelAction: {},
+            okAction: {}
+        )
+    }.padding(.horizontal, 52)
+}

--- a/Projects/Features/FeatureMy/Sources/Setting/SettingFeature.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/SettingFeature.swift
@@ -1,0 +1,16 @@
+import ComposableArchitecture
+import Shared
+
+@Reducer
+public struct SettingFeature {
+    @ObservableState
+    public struct State: Equatable {
+        public init() {}
+    }
+
+    public enum Action {}
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {}
+}

--- a/Projects/Features/FeatureMy/Sources/Setting/SettingFeature.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/SettingFeature.swift
@@ -5,12 +5,46 @@ import Shared
 public struct SettingFeature {
     @ObservableState
     public struct State: Equatable {
+        var isPopupPresented = false
+        var popupTitle = ""
+        var popupContent = ""
+
         public init() {}
     }
 
-    public enum Action {}
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case signoutButtonTapped
+        case resignButtonTapped
+        case dismissPopup
+        case popupOkButtonTapped
+    }
 
     public init() {}
 
-    public var body: some ReducerOf<Self> {}
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .signoutButtonTapped:
+                state.popupTitle = "로그아웃"
+                state.popupContent = "정말 로그아웃 하시겠습니까?\n로그아웃 시 다시 로그인해야 합니다."
+                state.isPopupPresented = true
+                return .none
+
+            case .resignButtonTapped:
+                state.popupTitle = "회원탈퇴"
+                state.popupContent = "정말 회원탈퇴 하시겠습니까?\n회원탈퇴 시 모든 정보가 사라집니다."
+                state.isPopupPresented = true
+                return .none
+
+            case .dismissPopup, .popupOkButtonTapped:
+                state.isPopupPresented = false
+                return .none
+
+            case .binding:
+                return .none
+            }
+        }
+    }
 }

--- a/Projects/Features/FeatureMy/Sources/Setting/SettingView.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/SettingView.swift
@@ -5,9 +5,6 @@ import DesignSystem
 struct SettingView: View {
     @Environment(\.dismiss) private var dismiss
     @Perception.Bindable private var store: StoreOf<SettingFeature>
-    @State private var isPopupPresented = false
-    @State private var popupTitle = ""
-    @State private var popupContent = ""
 
     init(store: StoreOf<SettingFeature>) {
         self.store = store
@@ -55,19 +52,11 @@ struct SettingView: View {
                     VStack(spacing: 16) {
                         SettingButton(
                             buttonText: "로그아웃",
-                            action: {
-                                popupTitle = "로그아웃"
-                                popupContent = "정말 로그아웃 하시겠습니까?\n로그아웃 시 다시 로그인해야 합니다."
-                                isPopupPresented = true
-                            }
+                            action: { store.send(.signoutButtonTapped) }
                         )
                         SettingButton(
                             buttonText: "회원탈퇴",
-                            action: {
-                                popupTitle = "회원탈퇴"
-                                popupContent = "정말 회원탈퇴 하시겠습니까?\n회원탈퇴 시 모든 정보가 사라집니다."
-                                isPopupPresented = true
-                            }
+                            action: { store.send(.resignButtonTapped) }
                         )
                     }
 
@@ -79,16 +68,16 @@ struct SettingView: View {
             .toolbar(.hidden, for: .navigationBar)
             .toolbar(.hidden, for: .tabBar)
             .overlay {
-                if isPopupPresented {
+                if store.isPopupPresented {
                     ZStack {
                         Color.black.opacity(0.5)
                             .ignoresSafeArea()
 
                         SettingPopup(
-                            title: popupTitle,
-                            content: popupContent,
-                            cancelAction: { isPopupPresented = false },
-                            okAction: { isPopupPresented = false }
+                            title: store.popupTitle,
+                            content: store.popupContent,
+                            cancelAction: { store.send(.dismissPopup) },
+                            okAction: { store.send(.popupOkButtonTapped) }
                         )
                         .padding(.horizontal, 52)
                     }

--- a/Projects/Features/FeatureMy/Sources/Setting/SettingView.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/SettingView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import DesignSystem
+
+struct SettingView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 20) {
+            HStack {
+                Button(action: { dismiss() }, label: {
+                    Image.Icons.leftArrow
+                        .foregroundStyle(Color.Gray.gray80)
+                })
+
+                Spacer()
+
+                Text("설정")
+                    .font(.finda(.body1))
+                    .foregroundColor(.Gray.gray90)
+
+                Spacer()
+
+                Image.Icons.leftArrow
+                    .opacity(0)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 8)
+
+            Spacer()
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
+        .toolbar(.hidden, for: .tabBar)
+    }
+}
+
+#Preview {
+    SettingView()
+}

--- a/Projects/Features/FeatureMy/Sources/Setting/SettingView.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/SettingView.swift
@@ -1,68 +1,107 @@
 import SwiftUI
+import ComposableArchitecture
 import DesignSystem
 
 struct SettingView: View {
     @Environment(\.dismiss) private var dismiss
+    @Perception.Bindable private var store: StoreOf<SettingFeature>
+    @State private var isPopupPresented = false
+    @State private var popupTitle = ""
+    @State private var popupContent = ""
+
+    init(store: StoreOf<SettingFeature>) {
+        self.store = store
+    }
 
     var body: some View {
-        VStack(spacing: 20) {
-            HStack {
-                Button(action: { dismiss() }, label: {
+        WithPerceptionTracking {
+            VStack(spacing: 20) {
+                HStack {
+                    Button(action: { dismiss() }, label: {
+                        Image.Icons.leftArrow
+                            .foregroundStyle(Color.Gray.gray80)
+                    })
+
+                    Spacer()
+
+                    Text("설정")
+                        .font(.finda(.body1))
+                        .foregroundColor(.Gray.gray90)
+
+                    Spacer()
+
                     Image.Icons.leftArrow
-                        .foregroundStyle(Color.Gray.gray80)
-                })
-
-                Spacer()
-
-                Text("설정")
-                    .font(.finda(.body1))
-                    .foregroundColor(.Gray.gray90)
-
-                Spacer()
-
-                Image.Icons.leftArrow
-                    .opacity(0)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 8)
-
-            VStack(spacing: 40) {
-                Image.Images.baseProfile
-                    .clipShape(.circle)
-
-                SettingButton(
-                    buttonText: "알림 설정",
-                    textColor: Color.Gray.gray90,
-                    action: {}
-                )
-                SettingButton(
-                    buttonText: "비밀번호 설정",
-                    textColor: Color.Blue.blue50,
-                    action: {}
-                )
-
-                VStack(spacing: 16) {
-                    SettingButton(
-                        buttonText: "로그아웃",
-                        action: {}
-                    )
-                    SettingButton(
-                        buttonText: "회원탈퇴",
-                        action: {}
-                    )
+                        .opacity(0)
+                        .accessibilityHidden(true)
                 }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 8)
 
-                Spacer()
+                VStack(spacing: 40) {
+                    Image.Images.baseProfile
+                        .clipShape(.circle)
+
+                    SettingButton(
+                        buttonText: "알림 설정",
+                        textColor: Color.Gray.gray90,
+                        action: {}
+                    )
+                    SettingButton(
+                        buttonText: "비밀번호 설정",
+                        textColor: Color.Blue.blue50,
+                        action: {}
+                    )
+
+                    VStack(spacing: 16) {
+                        SettingButton(
+                            buttonText: "로그아웃",
+                            action: {
+                                popupTitle = "로그아웃"
+                                popupContent = "정말 로그아웃 하시겠습니까?\n로그아웃 시 다시 로그인해야 합니다."
+                                isPopupPresented = true
+                            }
+                        )
+                        SettingButton(
+                            buttonText: "회원탈퇴",
+                            action: {
+                                popupTitle = "회원탈퇴"
+                                popupContent = "정말 회원탈퇴 하시겠습니까?\n회원탈퇴 시 모든 정보가 사라집니다."
+                                isPopupPresented = true
+                            }
+                        )
+                    }
+
+                    Spacer()
+                }
+                .padding(.horizontal, 24)
             }
-            .padding(.horizontal, 24)
+            .navigationBarBackButtonHidden(true)
+            .toolbar(.hidden, for: .navigationBar)
+            .toolbar(.hidden, for: .tabBar)
+            .overlay {
+                if isPopupPresented {
+                    ZStack {
+                        Color.black.opacity(0.5)
+                            .ignoresSafeArea()
+
+                        SettingPopup(
+                            title: popupTitle,
+                            content: popupContent,
+                            cancelAction: { isPopupPresented = false },
+                            okAction: { isPopupPresented = false }
+                        )
+                        .padding(.horizontal, 52)
+                    }
+                }
+            }
         }
-        .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden, for: .navigationBar)
-        .toolbar(.hidden, for: .tabBar)
     }
 }
 
 #Preview {
-    SettingView()
+    SettingView(
+        store: Store(initialState: SettingFeature.State()) {
+            SettingFeature()
+        }
+    )
 }

--- a/Projects/Features/FeatureMy/Sources/Setting/SettingView.swift
+++ b/Projects/Features/FeatureMy/Sources/Setting/SettingView.swift
@@ -27,7 +27,35 @@ struct SettingView: View {
             .padding(.horizontal, 24)
             .padding(.vertical, 8)
 
-            Spacer()
+            VStack(spacing: 40) {
+                Image.Images.baseProfile
+                    .clipShape(.circle)
+
+                SettingButton(
+                    buttonText: "알림 설정",
+                    textColor: Color.Gray.gray90,
+                    action: {}
+                )
+                SettingButton(
+                    buttonText: "비밀번호 설정",
+                    textColor: Color.Blue.blue50,
+                    action: {}
+                )
+
+                VStack(spacing: 16) {
+                    SettingButton(
+                        buttonText: "로그아웃",
+                        action: {}
+                    )
+                    SettingButton(
+                        buttonText: "회원탈퇴",
+                        action: {}
+                    )
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 24)
         }
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)

--- a/Projects/Features/FeatureMy/Sources/VolunteerHistory/Component/HistoryListCell.swift
+++ b/Projects/Features/FeatureMy/Sources/VolunteerHistory/Component/HistoryListCell.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import DesignSystem
+
+struct HistoryListCell: View {
+    var title: String
+    var date: String
+    var time: Int
+
+    init(
+        title: String,
+        date: String,
+        time: Int
+    ) {
+        self.title = title
+        self.date = date
+        self.time = time
+    }
+
+    var body: some View {
+        HStack {
+            VStack(spacing: 4) {
+                Text(title)
+                    .font(.finda(.body3))
+                    .foregroundStyle(Color.Gray.gray90)
+
+                Text(date)
+                    .font(.finda(.caption2))
+                    .foregroundStyle(Color.Gray.gray50)
+            }
+
+            Spacer()
+
+            Text("+ \(time)시간")
+                .font(.finda(.body3))
+                .foregroundStyle(Color.Blue.blue50)
+        }
+        .padding(20)
+        .background(Color.Gray.gray20)
+        .clipShape(.rect(cornerRadius: 10))
+    }
+}
+
+#Preview {
+    HistoryListCell(
+        title: "환경지킴이",
+        date: "2025.12.28",
+        time: 2
+    )
+}

--- a/Projects/Features/FeatureMy/Sources/VolunteerHistory/Component/HistoryListCell.swift
+++ b/Projects/Features/FeatureMy/Sources/VolunteerHistory/Component/HistoryListCell.swift
@@ -1,15 +1,16 @@
 import SwiftUI
 import DesignSystem
+import Foundation
 
 struct HistoryListCell: View {
     var title: String
     var date: String
-    var time: Int
+    var time: Float
 
     init(
         title: String,
         date: String,
-        time: Int
+        time: Float
     ) {
         self.title = title
         self.date = date
@@ -18,7 +19,7 @@ struct HistoryListCell: View {
 
     var body: some View {
         HStack {
-            VStack(spacing: 4) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.finda(.body3))
                     .foregroundStyle(Color.Gray.gray90)
@@ -30,7 +31,7 @@ struct HistoryListCell: View {
 
             Spacer()
 
-            Text("+ \(time)시간")
+            Text("+ \(String(format: "%.1f", time))시간")
                 .font(.finda(.body3))
                 .foregroundStyle(Color.Blue.blue50)
         }

--- a/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryFeature.swift
+++ b/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryFeature.swift
@@ -1,0 +1,27 @@
+import ComposableArchitecture
+import Shared
+
+@Reducer
+public struct VolunteerHistoryFeature {
+    @ObservableState
+    public struct State: Equatable {
+
+        public init() {}
+    }
+
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
+    }
+
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryView.swift
+++ b/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryView.swift
@@ -3,9 +3,14 @@ import DesignSystem
 
 struct VolunteerHistoryView: View {
     @Environment(\.dismiss) private var dismiss
+    private let historyItems: [VolunteerHistoryItem] = [
+        .init(title: "환경지킴이", date: "2025.12.28", time: 2),
+        .init(title: "iOS 멘토링", date: "2026.02.21", time: 100),
+        .init(title: "조기 귀가", date: "2025.10.02", time: 0.1)
+    ]
 
     var body: some View {
-        VStack {
+        VStack(spacing: 20) {
             HStack {
                 Button(action: { dismiss() }, label: {
                     Image.Icons.leftArrow
@@ -27,12 +32,36 @@ struct VolunteerHistoryView: View {
             .padding(.horizontal, 24)
             .padding(.vertical, 8)
 
-            Spacer()
+            VStack {
+                TotalTimeView(volunteerTime: 102.1)
+
+                ScrollView(showsIndicators: false) {
+                    LazyVStack(spacing: 12) {
+                        ForEach(historyItems) { item in
+                            HistoryListCell(
+                                title: item.title,
+                                date: item.date,
+                                time: item.time
+                            )
+                        }
+                    }
+                    .padding(.top, 20)
+                    .padding(.bottom, 12)
+                }
+            }
+            .padding(.horizontal, 24)
         }
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
         .toolbar(.hidden, for: .tabBar)
     }
+}
+
+private struct VolunteerHistoryItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let date: String
+    let time: Float
 }
 
 #Preview {

--- a/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryView.swift
+++ b/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryView.swift
@@ -1,59 +1,68 @@
 import SwiftUI
+import ComposableArchitecture
 import DesignSystem
 
 struct VolunteerHistoryView: View {
     @Environment(\.dismiss) private var dismiss
+    @Perception.Bindable private var store: StoreOf<VolunteerHistoryFeature>
+
     private let historyItems: [VolunteerHistoryItem] = [
         .init(title: "환경지킴이", date: "2025.12.28", time: 2),
         .init(title: "iOS 멘토링", date: "2026.02.21", time: 100),
         .init(title: "조기 귀가", date: "2025.10.02", time: 0.1)
     ]
 
+    init(store: StoreOf<VolunteerHistoryFeature>) {
+        self.store = store
+    }
+
     var body: some View {
-        VStack(spacing: 20) {
-            HStack {
-                Button(action: { dismiss() }, label: {
+        WithPerceptionTracking {
+            VStack(spacing: 20) {
+                HStack {
+                    Button(action: { dismiss() }, label: {
+                        Image.Icons.leftArrow
+                            .foregroundStyle(Color.Gray.gray80)
+                    })
+                    
+                    Spacer()
+                    
+                    Text("봉사활동 내역")
+                        .font(.finda(.body1))
+                        .foregroundColor(.Gray.gray90)
+                    
+                    Spacer()
+                    
                     Image.Icons.leftArrow
-                        .foregroundStyle(Color.Gray.gray80)
-                })
-
-                Spacer()
-
-                Text("봉사활동 내역")
-                    .font(.finda(.body1))
-                    .foregroundColor(.Gray.gray90)
-
-                Spacer()
-
-                Image.Icons.leftArrow
-                    .opacity(0)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 8)
-
-            VStack {
-                TotalTimeView(volunteerTime: 102.1)
-
-                ScrollView(showsIndicators: false) {
-                    LazyVStack(spacing: 12) {
-                        ForEach(historyItems) { item in
-                            HistoryListCell(
-                                title: item.title,
-                                date: item.date,
-                                time: item.time
-                            )
-                        }
-                    }
-                    .padding(.top, 20)
-                    .padding(.bottom, 12)
+                        .opacity(0)
+                        .accessibilityHidden(true)
                 }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 8)
+                
+                VStack {
+                    TotalTimeView(volunteerTime: 102.1)
+                    
+                    ScrollView(showsIndicators: false) {
+                        LazyVStack(spacing: 12) {
+                            ForEach(historyItems) { item in
+                                HistoryListCell(
+                                    title: item.title,
+                                    date: item.date,
+                                    time: item.time
+                                )
+                            }
+                        }
+                        .padding(.top, 20)
+                        .padding(.bottom, 12)
+                    }
+                }
+                .padding(.horizontal, 24)
             }
-            .padding(.horizontal, 24)
+            .navigationBarBackButtonHidden(true)
+            .toolbar(.hidden, for: .navigationBar)
+            .toolbar(.hidden, for: .tabBar)
         }
-        .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden, for: .navigationBar)
-        .toolbar(.hidden, for: .tabBar)
     }
 }
 
@@ -65,5 +74,9 @@ private struct VolunteerHistoryItem: Identifiable {
 }
 
 #Preview {
-    VolunteerHistoryView()
+    VolunteerHistoryView(
+        store: Store(initialState: VolunteerHistoryFeature.State()) {
+            VolunteerHistoryFeature()
+        }
+    )
 }

--- a/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryView.swift
+++ b/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import DesignSystem
+
+struct VolunteerHistoryView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack {
+            HStack {
+                Button(action: { dismiss() }, label: {
+                    Image.Icons.leftArrow
+                        .foregroundStyle(Color.Gray.gray80)
+                })
+
+                Spacer()
+
+                Text("봉사활동 내역")
+                    .font(.finda(.body1))
+                    .foregroundColor(.Gray.gray90)
+
+                Spacer()
+
+                Image.Icons.leftArrow
+                    .opacity(0)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 8)
+
+            Spacer()
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
+        .toolbar(.hidden, for: .tabBar)
+    }
+}
+
+#Preview {
+    VolunteerHistoryView()
+}

--- a/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryView.swift
+++ b/Projects/Features/FeatureMy/Sources/VolunteerHistory/VolunteerHistoryView.swift
@@ -24,25 +24,25 @@ struct VolunteerHistoryView: View {
                         Image.Icons.leftArrow
                             .foregroundStyle(Color.Gray.gray80)
                     })
-                    
+
                     Spacer()
-                    
+
                     Text("봉사활동 내역")
                         .font(.finda(.body1))
                         .foregroundColor(.Gray.gray90)
-                    
+
                     Spacer()
-                    
+
                     Image.Icons.leftArrow
                         .opacity(0)
                         .accessibilityHidden(true)
                 }
                 .padding(.horizontal, 24)
                 .padding(.vertical, 8)
-                
+
                 VStack {
                     TotalTimeView(volunteerTime: 102.1)
-                    
+
                     ScrollView(showsIndicators: false) {
                         LazyVStack(spacing: 12) {
                             ForEach(historyItems) { item in

--- a/Projects/Features/FeatureTeacher/FeatureTeacher.xcodeproj/project.pbxproj
+++ b/Projects/Features/FeatureTeacher/FeatureTeacher.xcodeproj/project.pbxproj
@@ -3,15 +3,15 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		5334046277BB1B64DE6549F1 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAB1566187A3993BADD819EB /* Shared.framework */; };
 		535B56C57694D2BD7C59A3A4 /* TeacherMainFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4592BD277596DB67E01241BF /* TeacherMainFeature.swift */; };
+		5EBE4EF5DB0F2D5297FA68F7 /* QRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D40B1DA3F5B865D72A5706 /* QRListView.swift */; };
 		60A14050F200114794A5A305 /* StudentListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A1737CE12CCD033F96ED0 /* StudentListCell.swift */; };
 		642AABB73B19A24F599A1E15 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6990196BB876AA6F5C32FFC /* DesignSystem.framework */; };
-		88B726DF2F48222A003AD410 /* QRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B726DE2F482225003AD410 /* QRListView.swift */; };
 		B26959CCED835F0E053CED5B /* QRCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606CD6600162E9A55A961491 /* QRCreateView.swift */; };
 		BAF16516E3485AED2F4EF3D4 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FDADF8C1E4459E6F8A2A8DF /* Core.framework */; };
 		CCEA6B85B7E7ACD8D2A2B523 /* TeacherMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D40C114790079CAF74CA13B /* TeacherMainView.swift */; };
@@ -33,12 +33,12 @@
 
 /* Begin PBXFileReference section */
 		0D40C114790079CAF74CA13B /* TeacherMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherMainView.swift; sourceTree = "<group>"; };
+		14D40B1DA3F5B865D72A5706 /* QRListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRListView.swift; sourceTree = "<group>"; };
 		1A30B36754A90FF14E11FBA4 /* ComposableArchitecture.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ComposableArchitecture.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FDADF8C1E4459E6F8A2A8DF /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4592BD277596DB67E01241BF /* TeacherMainFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherMainFeature.swift; sourceTree = "<group>"; };
 		513A1737CE12CCD033F96ED0 /* StudentListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentListCell.swift; sourceTree = "<group>"; };
 		606CD6600162E9A55A961491 /* QRCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCreateView.swift; sourceTree = "<group>"; };
-		88B726DE2F482225003AD410 /* QRListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRListView.swift; sourceTree = "<group>"; };
 		AFBF68F6060262D45624E86E /* PROD.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PROD.xcconfig; sourceTree = "<group>"; };
 		D6990196BB876AA6F5C32FFC /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D92B1DD6F25184CF3D4BDED0 /* FeatureTeacher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FeatureTeacher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -62,6 +62,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		25CD11C18313A7B26246D726 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				14D40B1DA3F5B865D72A5706 /* QRListView.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
 		2C838089801934F5E93911F0 /* FeatureTeacher */ = {
 			isa = PBXGroup;
 			children = (
@@ -108,18 +116,10 @@
 		8850EF35B37702D62B41440B /* QR */ = {
 			isa = PBXGroup;
 			children = (
-				88B726E02F482598003AD410 /* Component */,
+				25CD11C18313A7B26246D726 /* Component */,
 				606CD6600162E9A55A961491 /* QRCreateView.swift */,
 			);
 			path = QR;
-			sourceTree = "<group>";
-		};
-		88B726E02F482598003AD410 /* Component */ = {
-			isa = PBXGroup;
-			children = (
-				88B726DE2F482225003AD410 /* QRListView.swift */,
-			);
-			path = Component;
 			sourceTree = "<group>";
 		};
 		C3D854350045398BC7D479A4 /* Products */ = {
@@ -202,6 +202,8 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				ORGANIZATIONNAME = com.finda.app;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = 39EDC612B0BD3DE644494834 /* Build configuration list for PBXProject "FeatureTeacher" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -261,8 +263,8 @@
 				60A14050F200114794A5A305 /* StudentListCell.swift in Sources */,
 				535B56C57694D2BD7C59A3A4 /* TeacherMainFeature.swift in Sources */,
 				CCEA6B85B7E7ACD8D2A2B523 /* TeacherMainView.swift in Sources */,
+				5EBE4EF5DB0F2D5297FA68F7 /* QRListView.swift in Sources */,
 				B26959CCED835F0E053CED5B /* QRCreateView.swift in Sources */,
-				88B726DF2F48222A003AD410 /* QRListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -297,7 +299,21 @@
 					"-fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include/module.modulemap",
 					"-fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/tuist-derived/UIKitNavigationShim/UIKitNavigationShim.modulemap",
 				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/tuist-derived/UIKitNavigationShim/UIKitNavigationShim.modulemap -load-plugin-executable $BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/CasePathsMacros#CasePathsMacros -load-plugin-executable $BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/ComposableArchitectureMacros#ComposableArchitectureMacros -load-plugin-executable $BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/DependenciesMacrosPlugin#DependenciesMacrosPlugin -load-plugin-executable $BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/PerceptionMacros#PerceptionMacros";
+				OTHER_SWIFT_FLAGS = (
+					"$(inherited)",
+					"-Xcc",
+					"-fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include/module.modulemap",
+					"-Xcc",
+					"-fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/tuist-derived/UIKitNavigationShim/UIKitNavigationShim.modulemap",
+					"-load-plugin-executable",
+					"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/CasePathsMacros#CasePathsMacros",
+					"-load-plugin-executable",
+					"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/ComposableArchitectureMacros#ComposableArchitectureMacros",
+					"-load-plugin-executable",
+					"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/DependenciesMacrosPlugin#DependenciesMacrosPlugin",
+					"-load-plugin-executable",
+					"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/PerceptionMacros#PerceptionMacros",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.finda.app.featureteacher;
 				PRODUCT_NAME = FeatureTeacher;
 				SDKROOT = iphoneos;
@@ -464,7 +480,21 @@
 					"-fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include/module.modulemap",
 					"-fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/tuist-derived/UIKitNavigationShim/UIKitNavigationShim.modulemap",
 				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/tuist-derived/UIKitNavigationShim/UIKitNavigationShim.modulemap -load-plugin-executable $BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/CasePathsMacros#CasePathsMacros -load-plugin-executable $BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/ComposableArchitectureMacros#ComposableArchitectureMacros -load-plugin-executable $BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/DependenciesMacrosPlugin#DependenciesMacrosPlugin -load-plugin-executable $BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/PerceptionMacros#PerceptionMacros";
+				OTHER_SWIFT_FLAGS = (
+					"$(inherited)",
+					"-Xcc",
+					"-fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include/module.modulemap",
+					"-Xcc",
+					"-fmodule-map-file=$(SRCROOT)/../../../Tuist/.build/tuist-derived/UIKitNavigationShim/UIKitNavigationShim.modulemap",
+					"-load-plugin-executable",
+					"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/CasePathsMacros#CasePathsMacros",
+					"-load-plugin-executable",
+					"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/ComposableArchitectureMacros#ComposableArchitectureMacros",
+					"-load-plugin-executable",
+					"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/DependenciesMacrosPlugin#DependenciesMacrosPlugin",
+					"-load-plugin-executable",
+					"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/PerceptionMacros#PerceptionMacros",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.finda.app.featureteacher;
 				PRODUCT_NAME = FeatureTeacher;
 				SDKROOT = iphoneos;
@@ -472,7 +502,10 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## 개요

시간 내역 확인 및 설정 화면 Publishing

## 작업사항

- VolunteerHistoryView Publishing
- SettingView Publishing
- SettingPopup Component

## 변경로직

- 봉사시간 타입 Int -> Float

## UI

<img width="150" src="https://github.com/user-attachments/assets/a5641022-c329-4a74-aed5-07e1834f132e" /> 
<img width="150" src="https://github.com/user-attachments/assets/dedc0acf-0556-41cc-90f9-9d4f0601a067" />
<img width="150" src="https://github.com/user-attachments/assets/15a9cae5-182a-4e33-909d-3e522e364157" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 마이 탭 통합: 프로필, 설정, 자원봉사 이력 접근 가능
  * 설정 페이지 추가: 알림/비밀번호 설정, 로그아웃·회원탈퇴 팝업 제공
  * 자원봉사 이력 화면 추가: 항목별 이력과 총 봉사 시간 표시
* **기능 개선**
  * 봉사 시간 표시 정밀도 향상: 소수점 한 자리까지 표시 (예: 102.1시간)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->